### PR TITLE
fix(ProjectsDashboard): conditionally render admin action button

### DIFF
--- a/src/pages/ProjectsDashboard.tsx
+++ b/src/pages/ProjectsDashboard.tsx
@@ -917,17 +917,17 @@ export const ProjectsDashboard = () => {
   const leftActions = (
     <div className="flex items-center gap-4">
       {/* Action Button */}
-      {/* {
-        localStorage.getItem("selectedView") === "admin" && ( */}
-      <Button
-        className="bg-[#C72030] hover:bg-[#A01020] text-white"
-        onClick={() => setShowActionPanel(true)}
-      >
-        <Plus className="w-4 h-4 mr-2" />
-        Action
-      </Button>
-      {/* )
-      } */}
+      {
+        localStorage.getItem("selectedView") === "admin" && (
+          <Button
+            className="bg-[#C72030] hover:bg-[#A01020] text-white"
+            onClick={() => setShowActionPanel(true)}
+          >
+            <Plus className="w-4 h-4 mr-2" />
+            Action
+          </Button>
+        )
+      }
 
       {/* Total Projects Count */}
       <div className="flex items-center gap-2 px-4 py-1 bg-gray-50 rounded-lg border border-gray-200">


### PR DESCRIPTION
The action button was incorrectly always visible due to commented-out conditional logic. Uncomment the check for localStorage selectedView to ensure the button only appears for admin users.